### PR TITLE
Fix of conflict of c++ standard requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ add_definitions(${LLVM_DEFINITIONS})
 
 message("${LLVM_INCLUDE_DIRS}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 add_executable(kslicer 
                kslicer_main.cpp


### PR DESCRIPTION
Project requires c++17 standard.
It's already required in 3d line of CMakeLists.txt file.

If compiled with c++14 standard, next errors occur:

* std::make_pair should be used instead of std::pair constructor
* StringRef from llvm has explicit operator std::string(), so assignment to std::string (without explicit cast) can't be performed
* std::filesystem namespace is unknown in c++14